### PR TITLE
Enable the initialization of of EmbebedDocument's

### DIFF
--- a/lib/ripple/embedded_document.rb
+++ b/lib/ripple/embedded_document.rb
@@ -13,7 +13,8 @@ module Ripple
 
     module ClassMethods
       def instantiate(attrs)
-        self.new.tap do |object|
+        self.allocate.tap do |object|
+          object.instance_variable_set("@new", true)
           object.raw_attributes = attrs
         end
       end


### PR DESCRIPTION
When restoring from the database, ripple-light will call object.new
instead of object.allocated.

By modifying this behaviour, new (and initialize) will be only call by
the user as the library will allocate the object and assign the
attributes.
